### PR TITLE
Fix build bug for gcc 9.4.0: Include missing header.

### DIFF
--- a/include/mav/TCPClient.h
+++ b/include/mav/TCPClient.h
@@ -5,10 +5,10 @@
 #define LIBMAVLINK_TCP_H
 
 #include <sys/socket.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <atomic>
+#include <unistd.h>
 #include <csignal>
 #include "Network.h"
 

--- a/include/mav/UDPServer.h
+++ b/include/mav/UDPServer.h
@@ -9,6 +9,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <atomic>
+#include <unistd.h>
 #include <vector>
 #include <array>
 #include <csignal>


### PR DESCRIPTION
When trying to compile the libmav library i got an error that all the close, read, write functions could not be resolved. Including the unistd header solved the issue for me.