### PR TITLE
Differentiate interfaces by being connection oriented or not

### DIFF
--- a/include/mav/Serial.h
+++ b/include/mav/Serial.h
@@ -95,6 +95,10 @@ namespace mav {
             ::close(_fd);
         }
 
+        bool isConnectionOriented() const override {
+            return true;
+        }
+
         virtual ~Serial() {
             ::close(_fd);
         }

--- a/include/mav/TCPClient.h
+++ b/include/mav/TCPClient.h
@@ -86,6 +86,10 @@ namespace mav {
             }
         }
 
+        bool isConnectionOriented() const override {
+            return true;
+        }
+
         virtual ~TCPClient() {
             stop();
         }

--- a/include/mav/TCPServer.h
+++ b/include/mav/TCPServer.h
@@ -226,6 +226,11 @@ namespace mav {
             }
         }
 
+        bool isConnectionOriented() const override {
+            return true;
+        }
+
+
         void markMessageBoundary() override {
             // release the current socket, we can again accept data from any client socket
             _current_client_socket = -1;

--- a/include/mav/UDPClient.h
+++ b/include/mav/UDPClient.h
@@ -101,6 +101,12 @@ namespace mav {
             _bytes_available = 0;
         }
 
+        bool isConnectionOriented() const override {
+            // even though UDP is not connection oriented, we can use it as if it was,
+            // since we're using the connect() function to bind to a specific remote address
+            return true;
+        }
+
         virtual ~UDPClient() {
             stop();
         }


### PR DESCRIPTION
Allows sending heartbeats out before receiving heartbeats for connection oriented interfaces.